### PR TITLE
Report errors when called with bad table or chart id

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [the gallery of visualizations](https://community.modeanalytics.com/gallery)
 	```
 	alamode.sunburstChart(
 		{
-			html_elemnt: "#sunburst-div",
+			html_element: "#sunburst-div",
 	    	query_name: "My Sunburst Query",
 	    	title: "A chart built with alamode",
 	    	event_columns: ["event_1","event_2","event_3"],

--- a/alamode.css
+++ b/alamode.css
@@ -16,6 +16,12 @@
   font-weight: 500;
 }
 
+h1.mode-error {
+  padding: .2em 2em;
+  background: red;
+  color: white;
+}
+
 /*Retention heatmap styling*/
 .mode-retention-heatmap-pivot-label {
   font-size: 12px;

--- a/alamode.js
+++ b/alamode.js
@@ -2,6 +2,10 @@
 // 
 // Visualizations for Mode reports
 
+function reportError(msg) {
+  $("<h1 class='mode-error'>").text(msg).prependTo(document.body);
+}
+
 var alamode = {
   
   getColumnsFromQuery: function(queryName) {
@@ -9,7 +13,12 @@ var alamode = {
   },
   
   getDataFromQuery: function(queryName) {
-    return datasets.filter(function(d) { return d.queryName == queryName; })[0].content;
+    var data = datasets.filter(function(d) { return d.queryName == queryName; })[0];
+    if (!data) {
+      reportError("No such query: '" + queryName + "'");
+      return [];
+    }
+    return data.content;
   },
   
   makeId: function(chars) {
@@ -28,6 +37,8 @@ var alamode = {
     
     if (el == "body") {
       $("<div id='" + id + "'></div>").addClass(id).addClass("mode-graphic-container").appendTo(".mode-content");
+    } else if ($(el).length === 0) {
+      reportError("No such element: '" + el + "'");
     } else {
       $(el).addClass("mode-graphic-container");
       $(el).addClass(id)


### PR DESCRIPTION
Fix #1, report errors when called with bad table or chart id by inserting a big warning error banner at the top:

<img width="468" alt="screen shot 2016-12-16 at 02 11 29" src="https://cloud.githubusercontent.com/assets/225809/21259148/039e353e-c335-11e6-9a44-36bdedfbe72d.png">

See it in action: https://modeanalytics.com/editor/laughinghan/reports/b296289a24a3

Also, don't throw an exception if e.g. a bad query name (chart id?) is supplied, so the script can carry on and potentially render any subsequent valid charts.

Given the way I expect Mode Analytics users typically create and edit these dashboards, I'm assuming they don't usually have the Console open to see errors, and they're probably editing and re-running their code lots of times, so this seems like a reasonable way to report errors out-of-band. (Did you have something else in mind in #1?)

Potential future enhancement would be an option to be a little quieter about errors for more production-y dashboards, but unless people are using JS to dynamically generate these charts, it seems unlikely for these errors to happen except while editing your own dashboard.