### PR TITLE
Fix gradientValue undefined error

### DIFF
--- a/alamode.js
+++ b/alamode.js
@@ -574,6 +574,7 @@ var alamode = {
           gradientValue = d3.mean( _.map(matches,gradientColumn) );
         } else {
           entryValue = "";
+          gradientValue = "";
         }
         row = row.concat( {column: valueColumn, value: entryValue, cohort: cohort, pivot: p, gradientValue: gradientValue } )
       })


### PR DESCRIPTION
When using retentionHeatmap, if a dataValue is not present for a specific pivotValue, an error is currently thrown because gradientValue is not defined.