### PR TITLE
Added resizeTableHeight

### DIFF
--- a/alamode.js
+++ b/alamode.js
@@ -433,6 +433,15 @@ var alamode = {
 
     window.dispatchEvent(new Event('resize'));
   },
+  
+  resizeTableHeight: function(o) {
+    var chart = o["chart"],
+        height = o["height"];
+
+      $("#" + chart + " .table-renderer").css("height",height)
+
+    window.dispatchEvent(new Event('resize'));
+  },
 
   retentionHeatmap: function(o) {
 


### PR DESCRIPTION
The standard resizeChartHeight does not work for tables. Tables require a different selector: .table-renderer